### PR TITLE
Validate password length and limit input

### DIFF
--- a/passwordGenerator.py
+++ b/passwordGenerator.py
@@ -20,7 +20,7 @@ class PasswordGeneratorApp:
         self.title_label.pack(pady=10)
         self.label_length = tk.Label(self.root, text="Password Length:", bg="black", fg="white")
         self.label_length.pack()
-        self.password_length = tk.Entry(self.root, textvariable=self.password_length_value)
+        self.password_length = tk.Spinbox(self.root, from_=4, to=128, textvariable=self.password_length_value)
         self.password_length.pack()
         self.label_charset = tk.Label(self.root, text="Character Set:", bg="black", fg="white")
         self.label_charset.pack()
@@ -59,7 +59,15 @@ class PasswordGeneratorApp:
         self.password_listbox.bind("<<ListboxSelect>>", self.on_password_selected)
 
     def generate_password(self):
-        length = int(self.password_length.get())
+        try:
+            length = int(self.password_length.get())
+        except ValueError:
+            messagebox.showerror("Error", "Please enter a valid number for password length.")
+            return
+
+        if not 4 <= length <= 128:
+            messagebox.showerror("Error", "Password length must be between 4 and 128.")
+            return
         charset = ""
 
         if self.use_lowercase.get():


### PR DESCRIPTION
## Summary
- Replace password length entry with a Spinbox restricted to 4-128.
- Guard password length parsing with a try/except and range check, showing error dialogs for invalid input.

## Testing
- `python -m py_compile passwordGenerator.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2f9923ffc8328bd28862711744316